### PR TITLE
Header as associate array

### DIFF
--- a/src/Geotab/API.php
+++ b/src/Geotab/API.php
@@ -177,10 +177,9 @@ class API
             ],
             "headers" => [
                 "User-Agent" => "mygeotab-php/1.0",
-                "Content-Type: application/x-www-form-urlencoded",
-                "Charset=UTF-8",
-                "Cache-Control: no-cache",
-                "Pragma: no-cache"
+                "Content-Type" => "application/x-www-form-urlencoded; charset=utf-8",
+                "Cache-Control" => "no-cache",
+                "Pragma" => "no-cache"
             ],
             "decode_content" => "gzip",
             "verify" => false,   // Need CA certificates, but this is a hack


### PR DESCRIPTION
Headers were set via a mixture of string and associate array. Newer versions of guzzlehttp have a problem with this notation.